### PR TITLE
Add Cloud Platform scope to impersonated token providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.4.1
+
+- Add `"https://www.googleapis.com/auth/cloud-platform"` scope to impersonated providers
+
 ## v0.4.0
 
 - Add support for service account impersonation

--- a/pkg/tokenprovider/token_provider_gce.go
+++ b/pkg/tokenprovider/token_provider_gce.go
@@ -36,7 +36,7 @@ func NewImpersonatedGceAccessTokenProvider(cfg Config) TokenProvider {
 	return &tokenProviderImpl{
 		&impersonatedGceSource{
 			cacheKey:        createCacheKey("gce", &cfg),
-			scopes:          cfg.Scopes,
+			scopes:          append(cfg.Scopes, "https://www.googleapis.com/auth/cloud-platform"),
 			TargetPrincipal: cfg.TargetPrincipal,
 			Subject:         cfg.Subject,
 			Delegates:       cfg.Delegates,

--- a/pkg/tokenprovider/token_provider_jwt.go
+++ b/pkg/tokenprovider/token_provider_jwt.go
@@ -46,7 +46,7 @@ func NewImpersonatedJwtAccessTokenProvider(cfg Config) TokenProvider {
 				Email:      cfg.JwtTokenConfig.Email,
 				PrivateKey: cfg.JwtTokenConfig.PrivateKey,
 				TokenURL:   cfg.JwtTokenConfig.URI,
-				Scopes:     cfg.Scopes,
+				Scopes:     append(cfg.Scopes, "https://www.googleapis.com/auth/cloud-platform"),
 			},
 			TargetPrincipal: cfg.TargetPrincipal,
 			Subject:         cfg.Subject,


### PR DESCRIPTION
Add the `"https://www.googleapis.com/auth/cloud-platform"` scope to the impersonated token providers and update the changelog accordingly. This scope is required for the impersonation to work, without this we will get a 401 error.

Needs for https://github.com/grafana/google-bigquery-datasource/pull/344