### PR TITLE
Narrow token cache scope to the provider level

### DIFF
--- a/pkg/tokenprovider/token_provider_gce.go
+++ b/pkg/tokenprovider/token_provider_gce.go
@@ -24,23 +24,25 @@ type impersonatedGceSource struct {
 // NewGceAccessTokenProvider returns a token provider for gce authentication
 func NewGceAccessTokenProvider(cfg Config) TokenProvider {
 	return &tokenProviderImpl{
-		&gceSource{
+		tokenSource: &gceSource{
 			cacheKey: createCacheKey("gce", &cfg),
 			scopes:   cfg.Scopes,
 		},
+		cache: map[string]oauth2.Token{},
 	}
 }
 
 // NewImpersonatedGceAccessTokenProvider returns a token provider for an impersonated service account when using gce authentication
 func NewImpersonatedGceAccessTokenProvider(cfg Config) TokenProvider {
 	return &tokenProviderImpl{
-		&impersonatedGceSource{
+		tokenSource: &impersonatedGceSource{
 			cacheKey:        createCacheKey("gce", &cfg),
 			scopes:          append(cfg.Scopes, "https://www.googleapis.com/auth/cloud-platform"),
 			TargetPrincipal: cfg.TargetPrincipal,
 			Subject:         cfg.Subject,
 			Delegates:       cfg.Delegates,
 		},
+		cache: map[string]oauth2.Token{},
 	}
 }
 

--- a/pkg/tokenprovider/token_provider_jwt.go
+++ b/pkg/tokenprovider/token_provider_jwt.go
@@ -25,7 +25,7 @@ type impersonatedJwtSource struct {
 // NewJwtAccessTokenProvider returns a token provider for jwt file authentication
 func NewJwtAccessTokenProvider(cfg Config) TokenProvider {
 	return &tokenProviderImpl{
-		&jwtSource{
+		tokenSource: &jwtSource{
 			cacheKey: createCacheKey("jwt", &cfg),
 			conf: jwt.Config{
 				Email:      cfg.JwtTokenConfig.Email,
@@ -34,13 +34,14 @@ func NewJwtAccessTokenProvider(cfg Config) TokenProvider {
 				Scopes:     cfg.Scopes,
 			},
 		},
+		cache: map[string]oauth2.Token{},
 	}
 }
 
 // NewJwtAccessTokenProvider returns a token provider for an impersonated service account when using jwt file authentication
 func NewImpersonatedJwtAccessTokenProvider(cfg Config) TokenProvider {
 	return &tokenProviderImpl{
-		&impersonatedJwtSource{
+		tokenSource: &impersonatedJwtSource{
 			cacheKey: createCacheKey("jwt", &cfg),
 			conf: jwt.Config{
 				Email:      cfg.JwtTokenConfig.Email,
@@ -52,6 +53,7 @@ func NewImpersonatedJwtAccessTokenProvider(cfg Config) TokenProvider {
 			Subject:         cfg.Subject,
 			Delegates:       cfg.Delegates,
 		},
+		cache: map[string]oauth2.Token{},
 	}
 }
 

--- a/pkg/tokenprovider/token_provider_test.go
+++ b/pkg/tokenprovider/token_provider_test.go
@@ -104,7 +104,6 @@ func TestJwtTokenProvider(t *testing.T) {
 	})
 
 	t.Run("should use cached token on second call", func(t *testing.T) {
-		clearTokenCache()
 		fakeSource := fakeTokenSource{tokens: []string{"abc", ""}}
 		setUp(t, func(ctx context.Context, conf *jwt.Config) oauth2.TokenSource {
 			return &fakeSource
@@ -120,7 +119,6 @@ func TestJwtTokenProvider(t *testing.T) {
 	})
 
 	t.Run("should not use expired cached token", func(t *testing.T) {
-		clearTokenCache()
 		fakeSource := fakeTokenSource{tokens: []string{"abc", "def"}}
 		setUp(t, func(ctx context.Context, conf *jwt.Config) oauth2.TokenSource {
 			return &fakeSource
@@ -138,27 +136,7 @@ func TestJwtTokenProvider(t *testing.T) {
 		assert.Equal(t, "def", token2)
 	})
 
-	t.Run("should use cached token for same config", func(t *testing.T) {
-		clearTokenCache()
-		setUp(t, func(ctx context.Context, conf *jwt.Config) oauth2.TokenSource {
-			return &fakeTokenSource{tokens: []string{"abc"}}
-		})
-		provider1 := NewJwtAccessTokenProvider(config)
-		token1, err := provider1.GetAccessToken(context.Background())
-		require.NoError(t, err)
-		assert.Equal(t, "abc", token1)
-
-		setUp(t, func(ctx context.Context, conf *jwt.Config) oauth2.TokenSource {
-			return &fakeTokenSource{tokens: []string{"xyz"}}
-		})
-		provider2 := NewJwtAccessTokenProvider(config)
-		token2, err := provider2.GetAccessToken(context.Background())
-		require.NoError(t, err)
-		assert.Equal(t, "abc", token2)
-	})
-
 	t.Run("should not use cache for different scope", func(t *testing.T) {
-		clearTokenCache()
 		fakeSource := fakeTokenSource{tokens: []string{"abc", "def"}}
 		setUp(t, func(ctx context.Context, conf *jwt.Config) oauth2.TokenSource {
 			return &fakeSource
@@ -202,10 +180,4 @@ func TestNewImpersonatedJwtAccessTokenProvider_AddsCloudPlatformScope(t *testing
 
 	found := slices.Contains(src.conf.Scopes, "https://www.googleapis.com/auth/cloud-platform")
 	require.True(t, found, "cloud-platform scope should be present in scopes")
-}
-
-func clearTokenCache() {
-	tokenCache.Lock()
-	defer tokenCache.Unlock()
-	tokenCache.cache = map[string]*oauth2.Token{}
 }


### PR DESCRIPTION
Previously, we cached tokens in a global map. When any token read or write happened, we took an exclusive lock.

On a cache miss, we make network calls to get a valid token. If those network calls block, all requests that try to query will block, for all tenants sharing the same pod.

This change scopes the cache to the provider level.