### PR TITLE
fix(security): bump go directive to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-google-sdk-go
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-plugin-sdk-go v0.292.1


### PR DESCRIPTION
## Summary

- Bumps the `go` directive in `go.mod` from `1.26.3` → `1.26.4`
- Fixes two actively-called stdlib CVEs identified by `govulncheck`:
  - **GO-2026-5039**: Arbitrary inputs included in errors without escaping in `net/textproto` (call path: `utils.GCEDefaultProject` → `oauth2` → `textproto.Reader.ReadMIMEHeader`)
  - **GO-2026-5037**: Inefficient candidate hostname parsing in `crypto/x509` (call path: `oauth2` → `x509.Certificate.Verify`)
- CI picks up the new version automatically via `go-version-file: ./go.mod` in the setup-go action

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `govulncheck ./...` reports **No vulnerabilities found**

Made with [Cursor](https://cursor.com)