### PR TITLE
Add add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,35 @@
+name: Add issues & PRs to Grafana Data Source Plugins Squad project
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: grafana-oss-big-tent
+      - name: Add to project
+        id: add-to-project
+        uses: actions/add-to-project@828acb646a0a199a64596fa740761743d5f01b00 # main
+        with:
+          project-url: https://github.com/orgs/grafana/projects/1085 # Grafana Data Source Plugins Squad
+          github-token: ${{ steps.get-github-token.outputs.token }}
+      - uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751 # v0.1.0
+        id: update-project-fields
+        with:
+          project-url: https://github.com/orgs/grafana/projects/1085 # Grafana Data Source Plugins Squad
+          github-token: ${{ steps.get-github-token.outputs.token }}
+          item-id: ${{ steps.add-to-project.outputs.itemId }}
+          field-keys: Status
+          field-values: ${{ github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'renovate-sh-app[bot]' && 'Dependencies' || 'PR Need Review') || 'Incoming' }}


### PR DESCRIPTION
Adds a dedicated `add-to-project.yml` workflow that adds new issues and PRs to the [Grafana Data Source Plugins Squad project](https://github.com/orgs/grafana/projects/1085) on open, authorized via a scoped token from the GitHub App Token Broker (GATB).